### PR TITLE
Various fixes and improvements

### DIFF
--- a/src/malloc.h
+++ b/src/malloc.h
@@ -4,12 +4,22 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
 //==============================================================================
 // PROTOTYPES
 //==============================================================================
+
+/**
+ * Struct returned from pma_load()
+ */
+typedef struct _pma_root_state_t {
+  uint64_t  epoch;            // Epoch ID of the most recently processed event
+  uint64_t  event;            // ID of the most recently processed event
+  uint64_t  root;             // Root after most recent event
+} RootState;
 
 /**
  * Initialize a brand new PMA environment and event snapshot
@@ -25,14 +35,14 @@ pma_init(const char *path);
 /**
  * TODO
  */
-int
+RootState
 pma_load(const char *path);
 
 /**
  * TODO
  */
 int
-pma_close(uint64_t epoch, uint64_t event);
+pma_close(uint64_t epoch, uint64_t event, uint64_t root);
 
 /**
  * Allocate a new block of memory in the PMA
@@ -59,4 +69,10 @@ pma_free(void *address);
  * TODO
  */
 int
-pma_sync(uint64_t epoch, uint64_t event);
+pma_sync(uint64_t epoch, uint64_t event, uint64_t root);
+
+/**
+ * True if the address is in the PMA
+ */
+bool
+pma_in_arena(void *address);


### PR DESCRIPTION
These are mostly small bugs I ran into when trying to run this in urbit/new-mars#33.  They should mostly be self-explanatory, but I'm happy to explain any of them or go over this synchronously.

The changes I made beyond bug fixes are:

- Added `pma_in_arena(void*)` so the copying code knows whether it needs to copy a noun out.
- Added `root` to the metadata to record where the most recent root is, which will generally be the arvo state, bytecode cache, and anything else that needs to be persisted. You need this so that when you load, you know where to get started. There are a few possible variations, for example we could put the event number and epoch number inside the root as well.
- Made `pma_load` return the epoch number, event number, and root. Right now it returns these as a struct, but out parameters plus an error code return could be preferable.